### PR TITLE
Revert back to zachs git repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tannerdolby/speedlify"
+    "url": "git+https://github.com/zachleat/speedlify"
   },
   "bugs": {
-    "url": "https://github.com/tannerdolby/speedlify/issues"
+    "url": "https://github.com/zachleat/speedlify/issues"
   },
-  "homepage": "https://github.com/tannerdolby/speedlify/#readme",
+  "homepage": "https://github.com/zachleat/speedlify/#readme",
   "dependencies": {
     "@11ty/eleventy": "0.11.0",
     "@11ty/eleventy-cache-assets": "^2.0.3",


### PR DESCRIPTION
I think that the key/value pairs inside `package.json` should be left the same as the defaults. Therefore, this commit reverts back to the git URLs pointing to Zach's repository, as it's the main repository we cloned from. 